### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manual_test.yml
+++ b/.github/workflows/manual_test.yml
@@ -1,4 +1,6 @@
 name: Manual Tests
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/medspacy/medspacy_io/security/code-scanning/6](https://github.com/medspacy/medspacy_io/security/code-scanning/6)

The problem is that the workflow does not set explicit permissions for the `GITHUB_TOKEN`, thereby possibly inheriting overly permissive settings from the repository or organization. The best way to address this is to add a `permissions` block with the minimal set of privileges required. In this case, since the workflow only checks out code, sets up Python, installs dependencies, and runs tests—all actions that only need to read repository contents—the correct approach is to add `permissions: {contents: read}` to the root of the workflow YAML, just under the `name` field and before `on:`. This ensures that all jobs in the workflow, unless they have their own `permissions` key, will use this limited permission set.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
